### PR TITLE
allow alternative config for disc booting

### DIFF
--- a/src/libraries/ini.c
+++ b/src/libraries/ini.c
@@ -67,7 +67,7 @@ struct ini_info *ini_load(const char *filename) {
   f=fopen(filename, "r");
   if(!f) {
     fprintf(stderr, "%s:%s\n", filename, strerror(errno));
-    return 0;
+    return NULL;
   }
 
   /* create a new ini_info */

--- a/src/settings.c
+++ b/src/settings.c
@@ -133,16 +133,20 @@ int initSettings()
 
     DPRINTF("\n ** Initializing Settings **\n");
 
-    struct ini_info *ini = ini_load(settingsPath);
-
-    getINIString(ini, &settings.databasePath, "database", NULL);
-    getINIString(ini, &settings.databaseReadOnlyPath, "databaseReadOnly", NULL);
-    getINIString(ini, &settings.databaseReadWritePath, "databaseReadWrite", NULL);
-    getINIString(ini, &settings.bootPaths[0], "boot1", defaultBootPaths[0]);
-    getINIString(ini, &settings.bootPaths[1], "boot2", defaultBootPaths[1]);
-    getINIString(ini, &settings.bootPaths[2], "boot3", defaultBootPaths[2]);
-    getINIString(ini, &settings.bootPaths[3], "boot4", defaultBootPaths[3]);
-    getINIString(ini, &settings.bootPaths[4], "boot5", defaultBootPaths[4]);
+    struct ini_info *ini;
+    if (!(ini = ini_load(settingsPath))) {
+        ini = ini_load("CHTD.INI");
+    }
+    if (ini) {
+        getINIString(ini, &settings.databasePath, "database", NULL);
+        getINIString(ini, &settings.databaseReadOnlyPath, "databaseReadOnly", NULL);
+        getINIString(ini, &settings.databaseReadWritePath, "databaseReadWrite", NULL);
+        getINIString(ini, &settings.bootPaths[0], "boot1", defaultBootPaths[0]);
+        getINIString(ini, &settings.bootPaths[1], "boot2", defaultBootPaths[1]);
+        getINIString(ini, &settings.bootPaths[2], "boot3", defaultBootPaths[2]);
+        getINIString(ini, &settings.bootPaths[3], "boot4", defaultBootPaths[3]);
+        getINIString(ini, &settings.bootPaths[4], "boot5", defaultBootPaths[4]);
+    }
 
     migrateOldDatabaseSetting();
 


### PR DESCRIPTION
if usual config file is not found then `CHTD.INI` is looked at program location. a shorter name to fit on disc FS
